### PR TITLE
Fix: Resolve theme toggle flicker by robustly setting theme attributes

### DIFF
--- a/templates/js/darkmode.js
+++ b/templates/js/darkmode.js
@@ -1,5 +1,11 @@
   <script>
-  if (localStorage.getItem("theme") === "dark") {
+  const storedTheme = localStorage.getItem("theme");
+  if (storedTheme === "dark") {
     document.documentElement.classList.add("dark-mode");
+    document.documentElement.setAttribute("data-bs-theme", "dark");
+  } else {
+    // Handles 'light' or if theme is not set (null), default to light
+    document.documentElement.classList.remove("dark-mode");
+    document.documentElement.setAttribute("data-bs-theme", "light");
   }
   </script>


### PR DESCRIPTION
Modified templates/js/darkmode.js to set both the `dark-mode` class and the `data-bs-theme` attribute on the html element when loading the theme preference from localStorage.

This ensures that the theme is applied consistently and early in the page load process, preventing the UI from flickering between light and dark modes.